### PR TITLE
Bump libjvm to 1.31.1 to pull in Java 8 NMT fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/paketo-buildpacks/sap-machine
 go 1.15
 
 require (
-	github.com/paketo-buildpacks/libjvm v1.31.0
+	github.com/paketo-buildpacks/libjvm v1.31.1
 	github.com/paketo-buildpacks/libpak v1.54.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,11 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
-github.com/buildpacks/libcnb v1.22.0 h1:jnQf51ASouvsRv/F3cprStM3SrXxlueVP7MK7b8/km0=
 github.com/buildpacks/libcnb v1.22.0/go.mod h1:g++R17SOuahPXTGDj1tbIcLr9csmzHrNVoTsdocdaMc=
+github.com/buildpacks/libcnb v1.23.0 h1:i8bVCDgqfYqpULGLl/Td2V2quVzUqrngWKGwvsEASLc=
+github.com/buildpacks/libcnb v1.23.0/go.mod h1:wIXTSW6ybtX9XIICQQqPnIUxx6t1bSZT7iIOKbEzRH0=
 github.com/creack/pty v1.1.15 h1:cKRCLMj3Ddm54bKSpemfQ8AtYFBhAI2MPmdys22fBdc=
 github.com/creack/pty v1.1.15/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -60,8 +62,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.13.0/go.mod h1:lRk9szgn8TxENtWd0Tp4c3wjlRfMTMH27I+3Je41yGY=
 github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
-github.com/paketo-buildpacks/libjvm v1.31.0 h1:nz8W3FebQylc4O1xEArtRjpKaeJfV1XmiPncfDn9FR8=
-github.com/paketo-buildpacks/libjvm v1.31.0/go.mod h1:auLhSZJvLf9fUHApbUYgp9yN2X1Bgw3g1E1VeMopqtw=
+github.com/paketo-buildpacks/libjvm v1.31.1 h1:FjROulZf5Xv0JwlGXamEclpa8T4i7FV9WzDpIkKI1NU=
+github.com/paketo-buildpacks/libjvm v1.31.1/go.mod h1:ZWvoqjGB/uRl4c/vIKTTJ22KS/2QhOHFFx604671YJg=
 github.com/paketo-buildpacks/libpak v1.54.0 h1:jCAkIodm0hoJZoxq/Pnd6UwP1pObiwiqW13mdnePECc=
 github.com/paketo-buildpacks/libpak v1.54.0/go.mod h1:Q7A+Fc3aBGy4pLnp+LJHYA9oAmRyD43+ZHaFdXjI08g=
 github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0 h1:xKxUVGoB9VJU+lgQLPN0KURjw+XCVVSpHfQEeyxk3zo=


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Bump libjvm to 1.31.1 to pull in Java 8 NMT fix

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
