### PR TITLE
Use `latest_by_creation_time` flag for GH release action

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -22,58 +22,64 @@ dependencies:
   version_pattern: "11\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
-    glob:       sapmachine-jdk-.+_linux-x64_bin.tar.gz
-    owner:      SAP
-    repository: SapMachine
-    tag_filter: sapmachine-(11.*)
-    token:      ${{ secrets.JAVA_GITHUB_TOKEN }}
+    glob:                    sapmachine-jdk-.+_linux-x64_bin.tar.gz
+    owner:                   SAP
+    repository:              SapMachine
+    tag_filter:              sapmachine-(11.*)
+    latest_by_creation_time: true
+    token:                   ${{ secrets.JAVA_GITHUB_TOKEN }}
 - name:            JRE 11
   id:              jre
   version_pattern: "11\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
-    glob:       sapmachine-jre-.+_linux-x64_bin.tar.gz
-    owner:      SAP
-    repository: SapMachine
-    tag_filter: sapmachine-(11.*)
-    token:      ${{ secrets.JAVA_GITHUB_TOKEN }}
+    glob:                    sapmachine-jre-.+_linux-x64_bin.tar.gz
+    owner:                   SAP
+    repository:              SapMachine
+    tag_filter:              sapmachine-(11.*)
+    latest_by_creation_time: true
+    token:                   ${{ secrets.JAVA_GITHUB_TOKEN }}
 - name:            JDK 17
   id:              jdk
   version_pattern: "17\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
-    glob:       sapmachine-jdk-.+_linux-x64_bin.tar.gz
-    owner:      SAP
-    repository: SapMachine
-    tag_filter: sapmachine-(17.*)
-    token:      ${{ secrets.JAVA_GITHUB_TOKEN }}
+    glob:                    sapmachine-jdk-.+_linux-x64_bin.tar.gz
+    owner:                   SAP
+    repository:              SapMachine
+    tag_filter:              sapmachine-(17.*)
+    latest_by_creation_time: true
+    token:                   ${{ secrets.JAVA_GITHUB_TOKEN }}
 - name:            JRE 17
   id:              jre
   version_pattern: "17\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
-    glob:       sapmachine-jre-.+_linux-x64_bin.tar.gz
-    owner:      SAP
-    repository: SapMachine
-    tag_filter: sapmachine-(17.*)
-    token:      ${{ secrets.JAVA_GITHUB_TOKEN }}
+    glob:                    sapmachine-jre-.+_linux-x64_bin.tar.gz
+    owner:                   SAP
+    repository:              SapMachine
+    tag_filter:              sapmachine-(17.*)
+    latest_by_creation_time: true
+    token:                   ${{ secrets.JAVA_GITHUB_TOKEN }}
 - name:            JDK 18
   id:              jdk
   version_pattern: "18\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
-    glob:       sapmachine-jdk-.+_linux-x64_bin.tar.gz
-    owner:      SAP
-    repository: SapMachine
-    tag_filter: sapmachine-(18.*)
-    token:      ${{ secrets.JAVA_GITHUB_TOKEN }}
+    glob:                    sapmachine-jdk-.+_linux-x64_bin.tar.gz
+    owner:                   SAP
+    repository:              SapMachine
+    tag_filter:              sapmachine-(18.*)
+    latest_by_creation_time: true
+    token:                   ${{ secrets.JAVA_GITHUB_TOKEN }}
 - name:            JRE 18
   id:              jre
   version_pattern: "18\\.[\\d]+\\.[\\d]+"
   uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
   with:
-    glob:       sapmachine-jre-.+_linux-x64_bin.tar.gz
-    owner:      SAP
-    repository: SapMachine
-    tag_filter: sapmachine-(18.*)
-    token:      ${{ secrets.JAVA_GITHUB_TOKEN }}
+    glob:                    sapmachine-jre-.+_linux-x64_bin.tar.gz
+    owner:                   SAP
+    repository:              SapMachine
+    tag_filter:              sapmachine-(18.*)
+    latest_by_creation_time: true
+    token:                   ${{ secrets.JAVA_GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR enables the `latest_by_creation_time` GH release action option, introduced in https://github.com/paketo-buildpacks/pipeline-builder/pull/744, which fixes the semver incompatibility problem while looking for the latest releases. 

## Use Cases
<!-- An explanation of the use cases your change enables -->
As described in https://github.com/paketo-buildpacks/pipeline-builder/pull/744

> For projects that are using more than 3 digits in their version, after the [`NormalizeVersion`](https://github.com/paketo-buildpacks/pipeline-builder/blob/8e7b4fcd548529e787f07244fd4c732b6ad8f14b/actions/versions.go#L74) has modified the version from release, additional version digits are moved into the `PreRelease` field.
> 
> For example, the latest JDK 17 version of [SapMachine](https://github.com/SAP/SapMachine) is `17.0.3.0.1`, which is normalised to `17.0.3-0.1`. Following the Semver spec, `17.0.3` > `17.0.3-0.1`
> 
> For reference, [JEP-322](https://openjdk.org/jeps/322) reserves the 4th and 5th digits for upstream and vendor-specific changes.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
