### PR TITLE
Add deprecation_date to the buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -140,6 +140,7 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jdk:11.0.17:*:*:*:*:*:*:*"]
+    deprecation_date = "2023-09-30T00:00:00Z"
     id = "jdk"
     name = "SapMachine JDK"
     purl = "pkg:generic/sap-machine-jdk@11.0.17?arch=amd64"
@@ -154,6 +155,7 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jre:11.0.17:*:*:*:*:*:*:*"]
+    deprecation_date = "2023-09-30T00:00:00Z"
     id = "jre"
     name = "SapMachine JRE"
     purl = "pkg:generic/sap-machine-jre@11.0.17?arch=amd64"
@@ -168,6 +170,7 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jdk:17.0.5:*:*:*:*:*:*:*"]
+    deprecation_date = "2026-09-30T00:00:00Z"
     id = "jdk"
     name = "SapMachine JDK"
     purl = "pkg:generic/sap-machine-jdk@17.0.5?arch=amd64"
@@ -182,6 +185,7 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jre:17.0.5:*:*:*:*:*:*:*"]
+    deprecation_date = "2026-09-30T00:00:00Z"
     id = "jre"
     name = "SapMachine JRE"
     purl = "pkg:generic/sap-machine-jre@17.0.5?arch=amd64"
@@ -196,6 +200,7 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jdk:18.0.2:*:*:*:*:*:*:*"]
+    deprecation_date = "2022-09-30T00:00:00Z"
     id = "jdk"
     name = "SapMachine JDK"
     purl = "pkg:generic/sap-machine-jdk@18.0.2?arch=amd64"
@@ -210,6 +215,7 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jre:18.0.2:*:*:*:*:*:*:*"]
+    deprecation_date = "2022-09-30T00:00:00Z"
     id = "jre"
     name = "SapMachine JRE"
     purl = "pkg:generic/sap-machine-jre@18.0.2?arch=amd64"
@@ -224,6 +230,7 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jdk:19.0.1:*:*:*:*:*:*:*"]
+    deprecation_date = "2023-03-31T00:00:00Z"
     id = "jdk"
     name = "SapMachine JDK"
     purl = "pkg:generic/sap-machine-jdk@19.0.1?arch=amd64"
@@ -238,6 +245,7 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:oracle:jre:19.0.1:*:*:*:*:*:*:*"]
+    deprecation_date = "2023-03-31T00:00:00Z"
     id = "jre"
     name = "SapMachine JRE"
     purl = "pkg:generic/sap-machine-jre@19.0.1?arch=amd64"


### PR DESCRIPTION
## Summary
<!-- A short explanation of the proposed change -->

This change adds the deprecation dates to the `buildpack.toml` file. Support for that field was introduced in https://github.com/paketo-buildpacks/libpak/pull/179

## Use Cases
<!-- An explanation of the use cases your change enables -->

To print a warning message if a user receives a deprecated or soon-to-be-deprecated SapMachine version

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
