### PR TITLE
Use recommended approach to track tool dependencies

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -20,20 +20,13 @@ import (
 	"os"
 
 	"github.com/paketo-buildpacks/libjvm"
-	"github.com/paketo-buildpacks/libjvm/helper"
 	"github.com/paketo-buildpacks/libpak"
 	"github.com/paketo-buildpacks/libpak/bard"
 )
 
 func main() {
-	logger := bard.NewLogger(os.Stdout)
-
-	// not used directly, but this forces the helper module to be included in the module
-	// we need the helper module because of the way that `scripts/build/sh` builds the helper cmd
-	_ = helper.ActiveProcessorCount{Logger: logger}
-
 	libpak.Main(
 		libjvm.Detect{},
-		libjvm.NewBuild(logger),
+		libjvm.NewBuild(bard.NewLogger(os.Stdout)),
 	)
 }

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,7 @@
+// go:build tools
+
+package sapmachine
+
+import (
+	_ "github.com/paketo-buildpacks/libjvm/helper"
+)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

There's [an official recommendation](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module) on how to keep tool dependencies for a module in it's `go.mod` file, without including them during compilation.

With this change, the codebase of `github.com/paketo-buildpacks/libjvm/helper` will not end up in the output binary. As a tiny bonus, the binary size will be smaller:

before:
```console
$ ls -lah bin/main
-rwxr-xr-x   1 user  staff   6.4M 21 Dec 13:19 main
```

after:
```console
$ ls -lah bin/main
-rwxr-xr-x   1 user  staff   6.2M 21 Dec 13:20 main
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
