### PR TITLE
Change default Java version to 17

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -123,7 +123,7 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
-    default = "11"
+    default = "17"
     description = "the Java version"
     name = "BP_JVM_VERSION"
 


### PR DESCRIPTION
## Summary

Per [Paketo Java RFC 14](https://github.com/paketo-buildpacks/rfcs/blob/main/text/java/0014-selecting-default-java-version.md) we are changing the default version of Java selected by the buildpack to Java 17.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
