### PR TITLE
Update pipeline-descriptor.yml

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -23,28 +23,6 @@ docker_credentials:
   password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
 
 dependencies:
-- name:            JDK 11
-  id:              jdk
-  version_pattern: "11\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
-  with:
-    glob:                    sapmachine-jdk-.+_linux-x64_bin.tar.gz
-    owner:                   SAP
-    repository:              SapMachine
-    tag_filter:              sapmachine-(11.*)
-    latest_by_creation_time: true
-    token:                   ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-- name:            JRE 11
-  id:              jre
-  version_pattern: "11\\.[\\d]+\\.[\\d]+"
-  uses:            docker://ghcr.io/paketo-buildpacks/actions/github-release-dependency:main
-  with:
-    glob:                    sapmachine-jre-.+_linux-x64_bin.tar.gz
-    owner:                   SAP
-    repository:              SapMachine
-    tag_filter:              sapmachine-(11.*)
-    latest_by_creation_time: true
-    token:                   ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 - name:            JDK 17
   id:              jdk
   version_pattern: "17\\.[\\d]+\\.[\\d]+"


### PR DESCRIPTION
## Summary

Follow up to https://github.com/paketo-buildpacks/sap-machine/pull/475

## Use Cases

Java 11 was removed, the pipeline-descriptor file needs updating too.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
